### PR TITLE
cicd: Add CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [integration, main, experiment/*, solution/*]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
Satisfies the branch protection rule requiring Code Scanning results before PRs can merge. Scans JavaScript/TypeScript on push, PR creation and once weekly to monitor for emerging vulnerabilities.

Issue #7